### PR TITLE
Add WASM profile

### DIFF
--- a/profiles/cura_wasm.jinja
+++ b/profiles/cura_wasm.jinja
@@ -6,3 +6,10 @@ emsdk/3.1.50
 [settings]
 os=Emscripten
 arch=wasm
+
+[conf]
+tools.build:skip_test=True
+
+[options]
+curaengine:enable_plugins=False
+curaengine:enable_arcus=False

--- a/profiles/cura_wasm.jinja
+++ b/profiles/cura_wasm.jinja
@@ -1,0 +1,8 @@
+include(cura.jinja)
+
+[tool_requires]
+emsdk/3.1.50
+
+[settings]
+os=Emscripten
+arch=wasm


### PR DESCRIPTION
Used when building CuraEngine as wasm.

See https://github.com/Ultimaker/CuraEngine/pull/2025

This should automatically pull in the emsdk and nodejs and disable certain options (plugins, arcus) which currently don't work for emscripten.

use as follows (after merging to dev):
```
conan config install https://github.com/Ultimaker/conan-config.git -a "-b dev"
cd CuraEngine
rm -rf build && conan install . --build=missing --update -pr:b cura_build.jinja -pr:h cura_wasm.jinja
cmake --preset release
cmake --build --preset release
```