### PR TITLE
NP-207 Add cura_wasm.jinja profile

### DIFF
--- a/profiles/cura_wasm.jinja
+++ b/profiles/cura_wasm.jinja
@@ -1,0 +1,15 @@
+include(cura.jinja)
+
+[tool_requires]
+emsdk/3.1.50
+
+[settings]
+os=Emscripten
+arch=wasm
+
+[conf]
+tools.build:skip_test=True
+
+[options]
+curaengine:enable_plugins=False
+curaengine:enable_arcus=False


### PR DESCRIPTION
The new cura_wasm.jinja configuration profile has been added. This profile includes settings and options specific to Emscripten and WebAssembly (wasm), along with certain build, tool, and requirement configurations like skipping tests and disabling plugins.

This profile was already tested during the work on NP-5 and is merged on the dev branch

Contribute to NP-207

> [!NOTE]
> The Wasm binaries are always build on our Linux runners