### PR TITLE
NP-637 Add npm generator for Emscripten and WebAssembly builds

### DIFF
--- a/extensions/generators/npm.py
+++ b/extensions/generators/npm.py
@@ -15,13 +15,11 @@ class npm:
             return
 
         root_package = [dep for dep in self._conanfile.dependencies.direct_host.values()][0]
-        dist_path = Path(self._conanfile.generators_folder, "dist")
-        mkdir(self._conanfile, str(dist_path))
 
         # Copy the *.js and *.d.ts
-        copy(self._conanfile, "*.js", src=root_package.package_folder, dst=str(dist_path))
-        copy(self._conanfile, "*.d.ts", src=root_package.package_folder, dst=str(dist_path))
+        copy(self._conanfile, "*.js", src=root_package.package_folder, dst=self._conanfile.generators_folder)
+        copy(self._conanfile, "*.d.ts", src=root_package.package_folder, dst=self._conanfile.generators_folder)
 
         # Create the package.json
-        save(self._conanfile, str(Path(dist_path.parent, "package.json")),
+        save(self._conanfile, str(Path(self._conanfile.generators_folder, "package.json")),
              json.dumps(root_package.conf_info.get(f"user.{root_package.ref.name.lower()}:package_json")))

--- a/extensions/generators/npm.py
+++ b/extensions/generators/npm.py
@@ -1,7 +1,8 @@
 import json
 
 from conan import ConanFile
-from conan.tools.files import copy, mkdir, save
+from conan.errors import ConanException
+from conan.tools.files import copy, save
 from pathlib import Path
 
 
@@ -12,7 +13,7 @@ class npm:
     def generate(self):
         if self._conanfile.settings.os != "Emscripten":
             self._conanfile.output.error("Can only deploy to NPM when build for Emscripten")
-            return
+            raise ConanException("Can only deploy to NPM when build for Emscripten")
 
         root_package = [dep for dep in self._conanfile.dependencies.direct_host.values()][0]
 

--- a/extensions/generators/npm.py
+++ b/extensions/generators/npm.py
@@ -23,3 +23,7 @@ class npm:
         # Create the package.json
         save(self._conanfile, str(Path(self._conanfile.generators_folder, "package.json")),
              json.dumps(root_package.conf_info.get(f"user.{root_package.ref.name.lower()}:package_json")))
+
+        # Create the .npmrc file
+        save(self._conanfile, str(Path(self._conanfile.generators_folder, ".npmrc")),
+             "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}\n@ultimaker:registry=https://npm.pkg.github.com\nalways-auth=true")

--- a/extensions/generators/npm.py
+++ b/extensions/generators/npm.py
@@ -1,0 +1,27 @@
+import json
+
+from conan import ConanFile
+from conan.tools.files import copy, mkdir, save
+from pathlib import Path
+
+
+class npm:
+    def __init__(self, conanfile: ConanFile):
+        self._conanfile = conanfile
+
+    def generate(self):
+        if self._conanfile.settings.os != "Emscripten":
+            self._conanfile.output.error("Can only deploy to NPM when build for Emscripten")
+            return
+
+        root_package = [dep for dep in self._conanfile.dependencies.direct_host.values()][0]
+        dist_path = Path(self._conanfile.generators_folder, "dist")
+        mkdir(self._conanfile, str(dist_path))
+
+        # Copy the *.js and *.d.ts
+        copy(self._conanfile, "*.js", src=root_package.package_folder, dst=str(dist_path))
+        copy(self._conanfile, "*.d.ts", src=root_package.package_folder, dst=str(dist_path))
+
+        # Create the package.json
+        save(self._conanfile, str(Path(dist_path.parent, "package.json")),
+             json.dumps(root_package.conf_info.get(f"user.{root_package.ref.name.lower()}:package_json")))

--- a/profiles/cura.jinja
+++ b/profiles/cura.jinja
@@ -17,7 +17,7 @@ curaengine_grpc_definitions*:compiler.cppstd=20
 scripta*:compiler.cppstd=20
 umspatial*:compiler.cppstd=20
 dulcificum*:compiler.cppstd=20
-curator*:compiler.cppstd=20
+curator/*:compiler.cppstd=20
 
 [options]
 asio-grpc/*:local_allocator=recycling_allocator

--- a/profiles/cura.jinja
+++ b/profiles/cura.jinja
@@ -1,5 +1,13 @@
 include(default)
 
+[replace_requires]
+{% if platform.system() == 'Linux' %}
+# FIXME: once gRPC is updated to 1.67.0 or higher
+# Using 255.10 or higher https://github.com/conan-io/conan-center-index/issues/24889
+# https://github.com/conan-io/conan-center-index/blob/879e140d9438ab491aceea766d0cf0ae3595dae8/recipes/grpc/all/conanfile.py#L122
+libsystemd/*: libsystemd/[>=255.10]
+{% endif %}
+
 [settings]
 compiler.cppstd=17
 curaengine*:compiler.cppstd=20

--- a/profiles/cura_build.jinja
+++ b/profiles/cura_build.jinja
@@ -2,3 +2,8 @@ include(default)
 
 [settings]
 compiler.cppstd=17
+curator/*:compiler.cppstd=20
+
+[options]
+curator/*:with_cura_resources=True
+curator/*:with_cura_ted_resources=True

--- a/profiles/cura_build.jinja
+++ b/profiles/cura_build.jinja
@@ -4,6 +4,5 @@ include(default)
 compiler.cppstd=17
 curator/*:compiler.cppstd=20
 
-[options]
-curator/*:with_cura_resources=True
-curator/*:with_cura_ted_resources=True
+[conf]
+tools.build:skip_test=True

--- a/profiles/cura_clang.jinja
+++ b/profiles/cura_clang.jinja
@@ -1,13 +1,10 @@
 include(cura.jinja)
-
-[tool_requires]
+{% set compiler, version, compiler_exe = detect_api.detect_clang_compiler(compiler_exe="clang") %}
 
 [settings]
-compiler=clang
-compiler.version=18
+compiler={{ compiler }}
+compiler.version={{ version.major }}
 compiler.libcxx=libstdc++11
 
-[options]
-
 [conf]
-tools.build:compiler_executables={"c":"clang", "cpp":"clang++"}
+tools.build:compiler_executables={"c":"{{ compiler_exe }}", "cpp":"{{ compiler_exe }}++"}

--- a/profiles/cura_wasm.jinja
+++ b/profiles/cura_wasm.jinja
@@ -18,4 +18,5 @@ curaengine/*:enable_plugins=False
 curaengine/*:enable_arcus=False
 curator/*:with_cura_resources=True
 curator/*:disable_logging=True
+dulcificum/*:with_python_bindings=False
 libzip/*:crypto=False

--- a/profiles/cura_wasm.jinja
+++ b/profiles/cura_wasm.jinja
@@ -3,6 +3,7 @@ include(cura.jinja)
 [tool_requires]
 emsdk/3.1.65@ultimaker/stable
 nodejs/20.16.0@ultimaker/stable
+curator/[>=0.5.0-beta.1]@ultimaker/np_637
 
 [settings]
 os=Emscripten
@@ -11,10 +12,10 @@ arch=wasm
 [conf]
 tools.build:skip_test=True
 tools.cmake.cmake_layout:build_folder_vars=['settings.os']
-{% if os.getenv('CI') == 'true' %}
-user.curator:resource_path="{% os.getenv('GITHUB_WORKSPACE') %}/resources"
-user.curator:fdm_materials_path="{% os.getenv('GITHUB_WORKSPACE') %}/resources"
-{% endif %}
+{#{% if os.getenv('CI') == 'true' %}#}
+{#user.curator:resource_path="{% os.getenv('GITHUB_WORKSPACE') %}/resources"#}
+{#user.curator:fdm_materials_path="{% os.getenv('GITHUB_WORKSPACE') %}/resources"#}
+{#{% endif %}#}
 
 [options]
 curaengine/*:enable_plugins=False

--- a/profiles/cura_wasm.jinja
+++ b/profiles/cura_wasm.jinja
@@ -11,6 +11,10 @@ arch=wasm
 [conf]
 tools.build:skip_test=True
 tools.cmake.cmake_layout:build_folder_vars=['settings.os']
+{% if os.getenv('CI') == 'true' %}
+user.curator:resource_path="{% os.getenv('GITHUB_WORKSPACE') %}/resources"
+user.curator:fdm_materials_path="{% os.getenv('GITHUB_WORKSPACE') %}/resources"
+{% endif %}
 
 [options]
 curaengine/*:enable_plugins=False

--- a/profiles/cura_wasm.jinja
+++ b/profiles/cura_wasm.jinja
@@ -3,7 +3,6 @@ include(cura.jinja)
 [tool_requires]
 emsdk/3.1.65@ultimaker/stable
 nodejs/20.16.0@ultimaker/stable
-curator/[>=0.5.0-beta.1]@ultimaker/np_637
 
 [settings]
 os=Emscripten
@@ -12,10 +11,7 @@ arch=wasm
 [conf]
 tools.build:skip_test=True
 tools.cmake.cmake_layout:build_folder_vars=['settings.os']
-{#{% if os.getenv('CI') == 'true' %}#}
-{#user.curator:resource_path="{% os.getenv('GITHUB_WORKSPACE') %}/resources"#}
-{#user.curator:fdm_materials_path="{% os.getenv('GITHUB_WORKSPACE') %}/resources"#}
-{#{% endif %}#}
+user.curator:printers=['ultimaker_sketch','ultimaker_sketch_large','ultimaker_sketch_sprint','ultimaker_method']
 
 [options]
 curaengine/*:enable_plugins=False

--- a/profiles/cura_wasm.jinja
+++ b/profiles/cura_wasm.jinja
@@ -10,6 +10,7 @@ arch=wasm
 
 [conf]
 tools.build:skip_test=True
+tools.cmake.cmake_layout:build_folder_vars=['settings.os']
 
 [options]
 curaengine/*:enable_plugins=False


### PR DESCRIPTION
Introduce a new npm generator in the Conan extensions for deploying to NPM when building for Emscripten and WebAssembly architectures. This generator copies JavaScript and TypeScript declaration files to a distribution directory and creates a package.json file using configuration information from the root package.

Contribute to NP-637