### PR TITLE
Temporary patch fix for Windows installers

### DIFF
--- a/profiles/cura.jinja
+++ b/profiles/cura.jinja
@@ -14,6 +14,11 @@ curaengine*:compiler.cppstd=20
 curaengine_plugin_infill_generate*:compiler.cppstd=20
 curaengine_plugin_gradual_flow*:compiler.cppstd=20
 curaengine_grpc_definitions*:compiler.cppstd=20
+{% if platform.system() == 'Windows' %}
+# FIXME: Resolve Arcus null reference caused by MSVC 19.40
+# https://github.com/microsoft/STL/releases/tag/vs-2022-17.10
+arcus*:compiler.version=193
+{% endif %}
 scripta*:compiler.cppstd=20
 umspatial*:compiler.cppstd=20
 dulcificum*:compiler.cppstd=20


### PR DESCRIPTION
Unfortunately, it appears building Arcus with MSVC v19.40+ causes Cura to reference a null pointer during the initialization sequence. This is a potential temporary fix until Arcus can be patched to be successfully built with the latest MSVC compiler versions shipped with VS 2022.

[A bit more of a description can be found here.](https://github.com/Ultimaker/Cura/discussions/20205#discussioncomment-12180106)