### PR TITLE
CURA-12694 Use recipes_only for conan-center

### DIFF
--- a/remotes.json
+++ b/remotes.json
@@ -3,7 +3,8 @@
   {
    "name": "conancenter",
    "url": "https://center2.conan.io",
-   "verify_ssl": true
+   "verify_ssl": true,
+   "recipes_only": true
   },
   {
    "name": "cura-conan2",


### PR DESCRIPTION
This way we will stop using binary packages built by conan and only rely on those we have built ourselves, which should help avoiding binary conflicts in the future.

CURA-12694