### PR TITLE
Detect Windows ARM64 via env and use MSYS2

### DIFF
--- a/profiles/cura.jinja
+++ b/profiles/cura.jinja
@@ -54,7 +54,7 @@ onetbb/*:tbbproxy=False
 # FIXME: Once there is a msys2/cci.latest conan package for Widnows ARM, please remove this section.
 # https://github.com/msys2/msys2-installer
 # ONLY FOR ARM64 Windows: use locally-installed MSYS2 instead of msys2/cci.latest (x86_64-only)
-# Currently there is no conan package recipe with suuport for ARM64 Windows
+# Currently there is no conan package recipe with support for ARM64 Windows
 tools.microsoft.bash:subsystem=msys2
 tools.microsoft.bash:path={{ os.environ.get("MSYS2_BASH", "C:/msys64/usr/bin/bash.exe") }}
 {% endif %}

--- a/profiles/cura.jinja
+++ b/profiles/cura.jinja
@@ -40,13 +40,20 @@ dulcificum/*:shared=True
 {% endif %}
 clipper/*:shared=True
 hwloc/*:shared=True
-{% if platform.system() == 'Windows' and platform.machine() in ['arm64', 'aarch64', 'ARM64'] %}
+{% if platform.system() == 'Windows' and os.environ.get('PROCESSOR_ARCHITECTURE', '').upper() == 'ARM64' %}
 # ARM64 Windows: CPython requires mpdecimal as shared library
 mpdecimal/*:shared=True
 # ARM64 Windows: Arcus needs to be shared for proper Python binding
 arcus/*:shared=True
 # ARM64 Windows: Disable tbbproxy (not available on ARM64 platforms)
 onetbb/*:tbbproxy=False
+{% endif %}
+
+[conf]
+{% if platform.system() == 'Windows' and os.environ.get('PROCESSOR_ARCHITECTURE', '').upper() == 'ARM64' %}
+# ARM64 Windows: use locally-installed MSYS2 instead of msys2/cci.latest (x86_64-only)
+tools.microsoft.bash:subsystem=msys2
+tools.microsoft.bash:path={{ os.environ.get("MSYS2_BASH", "C:/msys64/usr/bin/bash.exe") }}
 {% endif %}
 
 [replace_requires]

--- a/profiles/cura.jinja
+++ b/profiles/cura.jinja
@@ -51,7 +51,10 @@ onetbb/*:tbbproxy=False
 
 [conf]
 {% if platform.system() == 'Windows' and os.environ.get('PROCESSOR_ARCHITECTURE', '').upper() == 'ARM64' %}
-# ARM64 Windows: use locally-installed MSYS2 instead of msys2/cci.latest (x86_64-only)
+# FIXME: Once there is a msys2/cci.latest conan package for Widnows ARM, please remove this section.
+# https://github.com/msys2/msys2-installer
+# ONLY FOR ARM64 Windows: use locally-installed MSYS2 instead of msys2/cci.latest (x86_64-only)
+# Currently there is no conan package recipe with suuport for ARM64 Windows
 tools.microsoft.bash:subsystem=msys2
 tools.microsoft.bash:path={{ os.environ.get("MSYS2_BASH", "C:/msys64/usr/bin/bash.exe") }}
 {% endif %}

--- a/profiles/cura_build.jinja
+++ b/profiles/cura_build.jinja
@@ -10,7 +10,7 @@ tools.build:skip_test=True
 # FIXME: Once there is a msys2/cci.latest conan package for Widnows ARM, please remove this section.
 # https://github.com/msys2/msys2-installer
 # ONLY FOR ARM64 Windows: use locally-installed MSYS2 instead of msys2/cci.latest (x86_64-only)
-# Currently there is no conan package recipe with suuport for ARM64 Windows
+# Currently there is no conan package recipe with support for ARM64 Windows
 tools.microsoft.bash:subsystem=msys2
 tools.microsoft.bash:path={{ os.environ.get("MSYS2_BASH", "C:/msys64/usr/bin/bash.exe") }}
 {% endif %}

--- a/profiles/cura_build.jinja
+++ b/profiles/cura_build.jinja
@@ -7,7 +7,10 @@ curator/*:compiler.cppstd=20
 [conf]
 tools.build:skip_test=True
 {% if platform.system() == 'Windows' and os.environ.get('PROCESSOR_ARCHITECTURE', '').upper() == 'ARM64' %}
-# ARM64 Windows: use locally-installed MSYS2 (msys2/cci.latest only supports x86_64)
+# FIXME: Once there is a msys2/cci.latest conan package for Widnows ARM, please remove this section.
+# https://github.com/msys2/msys2-installer
+# ONLY FOR ARM64 Windows: use locally-installed MSYS2 instead of msys2/cci.latest (x86_64-only)
+# Currently there is no conan package recipe with suuport for ARM64 Windows
 tools.microsoft.bash:subsystem=msys2
 tools.microsoft.bash:path={{ os.environ.get("MSYS2_BASH", "C:/msys64/usr/bin/bash.exe") }}
 {% endif %}

--- a/profiles/cura_build.jinja
+++ b/profiles/cura_build.jinja
@@ -6,3 +6,8 @@ curator/*:compiler.cppstd=20
 
 [conf]
 tools.build:skip_test=True
+{% if platform.system() == 'Windows' and os.environ.get('PROCESSOR_ARCHITECTURE', '').upper() == 'ARM64' %}
+# ARM64 Windows: use locally-installed MSYS2 (msys2/cci.latest only supports x86_64)
+tools.microsoft.bash:subsystem=msys2
+tools.microsoft.bash:path={{ os.environ.get("MSYS2_BASH", "C:/msys64/usr/bin/bash.exe") }}
+{% endif %}


### PR DESCRIPTION
The msys package only contains tarballs and packages for x86_64
So the conan package available is only supporting x86_64 (and raising an invalid configuration error).
The ARM installer can be used but in the build steps to mitigate the conan invalid configuration without changing the conan recipe.
The current approach (profile points at local (msys64 via MSYS2_BASH, bypassing the conan package) is the temp solution until MSYS2 ships native ARM64 GNU tools.